### PR TITLE
Migrate from screen to wakelock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.25
+
+* Migrate from `screen` to `wakelock`.
+
 ## 1.0.24
 
 * Update interval for use path_provider

--- a/lib/page/video.dart
+++ b/lib/page/video.dart
@@ -15,8 +15,8 @@ class _VideoState extends State<Video> {
 
   @override
   void initState() {
-    Screen.keepOn(true);
     super.initState();
+    Wakelock.enable();
     bloc.getCameras();
     bloc.cameras.listen((data) {
       bloc.controllCamera = CameraController(data[0], ResolutionPreset.medium);
@@ -29,9 +29,9 @@ class _VideoState extends State<Video> {
 
   @override
   void dispose() {
-    super.dispose();
     bloc.dispose();
-    Screen.keepOn(false);
+    Wakelock.disable();
+    super.dispose();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: camera_camera
 description:  Um Flutter Plugin de câmera, que funciona tanto em iOS e Android. Na parte da câmera temos a parte editável. Para Android minSDK 21.
-version: 1.0.24
+version: 1.0.25
 author: Gabriel Sávio - Flutterando <gbrlsavio2@gmail.com>
 repository: https://github.com/gabuldev/camera_camera
 homepage: https://github.com/gabulsavul
@@ -15,7 +15,7 @@ dependencies:
   path_provider: ">=1.0.0 <2.0.0"
   image_cropper: 1.0.0
   native_device_orientation: ^0.2.0
-  screen: ^0.0.5
+  wakelock: ^0.1.3
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
As I [explained here](https://stackoverflow.com/a/56918918/6509751), `screen` lacks maintenance, which causes some problems. Migrating to `wakelock` resolves these problems.