### PR TITLE
make _cameraController nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+- Make `_cameraController` nullable. Fixes #51
+
 # 2.0.0-nullsafety.2
 
 - Add example on nullsafety

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: camera_camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-nullsafety"
+    version: "2.0.0"
   camera_platform_interface:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  camera_camera: 2.0.0-nullsafety.2
+  camera_camera: ^2.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/src/core/camera_bloc.dart
+++ b/lib/src/core/camera_bloc.dart
@@ -11,7 +11,7 @@ class CameraBloc {
   void Function(String value) onPath;
   CameraSide cameraSide;
   List<FlashMode> flashModes;
-  late CameraCameraController _cameraController;
+  CameraCameraController? _cameraController;
 
   CameraBloc({
     required this.service,
@@ -72,7 +72,7 @@ class CameraBloc {
   void startPreview(
     ResolutionPreset resolutionPreset,
   ) async {
-    await _cameraController.dispose();
+    await _cameraController?.dispose();
     await Future.delayed(Duration(milliseconds: 800));
 
     final cameras = status.selected.cameras;
@@ -84,7 +84,7 @@ class CameraBloc {
       flashModes: flashModes,
     );
     status = CameraStatusPreview(
-        controller: _cameraController,
+        controller: _cameraController!,
         cameras: cameras,
         indexSelected: indexSelected);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: camera_camera
 description: The easy plugin camera for your project, platforms Android and iOS.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/gabuldev/camera_camera
 homepage: https://gabul.dev/
 


### PR DESCRIPTION
Fixes `LateInitializationError: Field '_cameraController' has not been initialized` error from https://github.com/gabuldev/camera_camera/issues/51
