### PR TITLE
Added option not to use audio

### DIFF
--- a/lib/src/core/camera_bloc.dart
+++ b/lib/src/core/camera_bloc.dart
@@ -12,12 +12,14 @@ class CameraBloc {
   CameraSide cameraSide;
   List<FlashMode> flashModes;
   CameraCameraController? _cameraController;
+  bool enableAudio;
 
   CameraBloc({
     required this.service,
     required this.onPath,
     required this.cameraSide,
     required this.flashModes,
+    this.enableAudio = false,
   });
 
   //STREAM STATUS
@@ -82,6 +84,7 @@ class CameraBloc {
       resolutionPreset: resolutionPreset,
       onPath: onPath,
       flashModes: flashModes,
+      enableAudio: enableAudio,
     );
     status = CameraStatusPreview(
         controller: _cameraController!,

--- a/lib/src/presentation/camera_page.dart
+++ b/lib/src/presentation/camera_page.dart
@@ -19,11 +19,15 @@ class CameraCamera extends StatefulWidget {
   ///Define types of camera side is enabled
   final CameraSide cameraSide;
 
-  ///Define your FlashMode accepteds
+  ///Define your accepted [FlashMode]s
   final List<FlashMode> flashModes;
 
   ///Enable zoom camera ( default = true )
   final bool enableZoom;
+
+  ///Whether to allow audio recording. This can remove the microphone
+  ///permission on Android
+  final bool enableAudio;
 
   CameraCamera({
     Key? key,
@@ -32,6 +36,7 @@ class CameraCamera extends StatefulWidget {
     this.cameraSide = CameraSide.all,
     this.flashModes = FlashMode.values,
     this.enableZoom = true,
+    this.enableAudio = false,
   }) : super(key: key);
 
   @override
@@ -48,6 +53,7 @@ class _CameraCameraState extends State<CameraCamera> {
       service: CameraServiceImpl(),
       onPath: (path) => widget.onFile(File(path)),
       cameraSide: widget.cameraSide,
+      enableAudio: widget.enableAudio,
     );
     bloc.init();
     _subscription = bloc.statusStream.listen((state) {

--- a/lib/src/presentation/controller/camera_camera_controller.dart
+++ b/lib/src/presentation/controller/camera_camera_controller.dart
@@ -9,6 +9,7 @@ class CameraCameraController {
   CameraDescription cameraDescription;
   List<FlashMode> flashModes;
   void Function(String path) onPath;
+  bool enableAudio;
 
   late CameraController _controller;
 
@@ -21,8 +22,10 @@ class CameraCameraController {
     required this.cameraDescription,
     required this.flashModes,
     required this.onPath,
+    this.enableAudio = false,
   }) {
-    _controller = CameraController(cameraDescription, resolutionPreset);
+    _controller = CameraController(cameraDescription, resolutionPreset,
+        enableAudio: enableAudio);
   }
 
   void init() async {


### PR DESCRIPTION
The `camera` package allows to set the parameter `enableAudio` in the `CameraController` to false in case you do not want to record video / silen video. Together with https://github.com/flutter/flutter/issues/80649, this can remove the MICROPHONE permission from the application.

Fixes #61.