### PR TITLE
Update rxdart dep to 0.27.3

### DIFF
--- a/lib/src/core/camera_bloc.dart
+++ b/lib/src/core/camera_bloc.dart
@@ -26,7 +26,7 @@ class CameraBloc {
   final statusStream =
       BehaviorSubject<CameraStatus>.seeded(CameraStatusEmpty());
   CameraStatus get status =>
-      statusStream.valueWrapper?.value ?? CameraStatusEmpty();
+      statusStream.valueOrNull ?? CameraStatusEmpty();
   set status(CameraStatus status) => statusStream.sink.add(status);
 
   void init() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,7 +169,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.26.0"
+    version: "0.27.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   camera: ^0.9.4+5 
   font_awesome_flutter: ^9.0.0-nullsafety
-  rxdart: ^0.26.0
+  rxdart: ^0.27.3
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Update the rxdart dependency to version 0.27.3 to resolve conflicts with other packages. The `ValueStream.valueWrapper` was removed in rxdart version 0.27.0 and replaced with `valueOrNull` (see [here](https://pub.dev/packages/rxdart/changelog)).